### PR TITLE
Update sync screen to display original and remixed playlist details

### DIFF
--- a/apps/website/src/app/pages/sync-remixed-playlist/sync-remixed-playlist-page.component.html
+++ b/apps/website/src/app/pages/sync-remixed-playlist/sync-remixed-playlist-page.component.html
@@ -5,6 +5,22 @@
   </div>
 } @else {
   <div class="container mx-auto my-3 pb-16">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+      <div class="bg-base-300 rounded-lg p-4 flex items-center">
+        <img class="w-48 h-48 rounded-lg mr-4" [src]="originalPlaylist?.images[0].url" alt="Original Playlist Cover">
+        <div>
+          <h3 class="text-xl font-bold">{{originalPlaylist?.name}}</h3>
+          <p>{{originalPlaylist?.description}}</p>
+        </div>
+      </div>
+      <div class="bg-base-300 rounded-lg p-4 flex items-center justify-end text-right">
+        <div>
+          <h3 class="text-xl font-bold">{{remixedPlaylist?.name}}</h3>
+          <p>{{remixedPlaylist?.description}}</p>
+        </div>
+        <img class="w-48 h-48 rounded-lg ml-4" [src]="remixedPlaylist?.images[0].url" alt="Remixed Playlist Cover">
+      </div>
+    </div>
     <div class="grid md:grid-cols-2 gap-4">
       <div>
         <h2>Changed Tracks</h2>
@@ -75,4 +91,3 @@
     </button>
   </div>
 }
-

--- a/apps/website/src/app/pages/sync-remixed-playlist/sync-remixed-playlist-page.component.html
+++ b/apps/website/src/app/pages/sync-remixed-playlist/sync-remixed-playlist-page.component.html
@@ -5,20 +5,13 @@
   </div>
 } @else {
   <div class="container mx-auto my-3 pb-16">
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-      <div class="bg-base-300 rounded-lg p-4 flex items-center">
-        <img class="w-48 h-48 rounded-lg mr-4" [src]="originalPlaylist?.images[0].url" alt="Original Playlist Cover">
-        <div>
-          <h3 class="text-xl font-bold">{{originalPlaylist?.name}}</h3>
-          <p>{{originalPlaylist?.description}}</p>
-        </div>
-      </div>
-      <div class="bg-base-300 rounded-lg p-4 flex items-center justify-end text-right">
-        <div>
-          <h3 class="text-xl font-bold">{{remixedPlaylist?.name}}</h3>
-          <p>{{remixedPlaylist?.description}}</p>
-        </div>
-        <img class="w-48 h-48 rounded-lg ml-4" [src]="remixedPlaylist?.images[0].url" alt="Remixed Playlist Cover">
+    <div class="bg-base-300 rounded-lg flex items-center overflow-hidden mb-4">
+      @if (originalPlaylist && originalPlaylist.images[0].url) {
+        <img class="w-40 h-40 mr-4" [src]="originalPlaylist.images[0].url" alt="Original Playlist Cover">
+      }
+      <div class="p-4">
+        <h3 class="text-xl font-bold">{{ originalPlaylist?.name }}</h3>
+        <p>{{ originalPlaylist?.description }}</p>
       </div>
     </div>
     <div class="grid md:grid-cols-2 gap-4">
@@ -42,7 +35,8 @@
               [showPreview]="true"
               [track]="diff[1]">
               <div class="flex flex-col">
-                <span class="mb-3 text-gray-900 text-center font-semibold text-sm">{{getDiffIdentifierText(diff[0])}}</span>
+                <span
+                  class="mb-3 text-gray-900 text-center font-semibold text-sm">{{ getDiffIdentifierText(diff[0]) }}</span>
                 <button class="btn btn-success glass" (click)="addTrackToPreviewSyncedPlaylist(diff)">
                   Add to Preview
                   <fa-icon [icon]="arrowRightIcon"></fa-icon>
@@ -68,7 +62,8 @@
               [track]="track[1]">
               @if (track[0] !== DiffIdentifier.UNCHANGED) {
                 <div class="flex flex-col">
-                  <span class="mb-3 text-gray-900 text-center font-semibold text-sm">{{getDiffIdentifierText(track[0])}}</span>
+                  <span
+                    class="mb-3 text-gray-900 text-center font-semibold text-sm">{{ getDiffIdentifierText(track[0]) }}</span>
                   <button class="btn btn-error glass" (click)="removeTrackFromPreviewSyncedPlaylist(track)">
                     Remove from Preview
                     <fa-icon [icon]="arrowLeftIcon"></fa-icon>

--- a/apps/website/src/app/pages/sync-remixed-playlist/sync-remixed-playlist-page.component.ts
+++ b/apps/website/src/app/pages/sync-remixed-playlist/sync-remixed-playlist-page.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { LoadingComponent } from '../../components/loading/loading.component';
 import { SpotifyTrackComponent } from '../../components/spotify-track/spotify-track.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { Diff, DiffIdentifier } from '@spotify-manager/core';
+import { Diff, DiffIdentifier, SinglePlaylistResponse } from '@spotify-manager/core';
 import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
 import { Navigation, Router } from '@angular/router';
 import { ApiService } from '../../services/api/api.service';
@@ -30,9 +30,7 @@ export class SyncRemixedPlaylistPageComponent {
   arrowLeftIcon = faArrowLeft;
   isSyncing = false;
 
-  // Fields for storing fetched playlist details
-  originalPlaylist: SpotifyApi.SinglePlaylistResponse | undefined;
-  remixedPlaylist: SpotifyApi.SinglePlaylistResponse | undefined;
+  originalPlaylist: SinglePlaylistResponse | undefined;
 
   constructor(
     private readonly router: Router,
@@ -76,8 +74,6 @@ export class SyncRemixedPlaylistPageComponent {
   private async fetchPlaylistDetails() {
     // Fetch the original playlist details
     this.originalPlaylist = await this.apiService.getPlaylist(this.originalPlaylistId);
-    // Fetch the remixed playlist details
-    this.remixedPlaylist = await this.apiService.getPlaylist(this.remixedPlaylistId);
   }
 
   /**

--- a/apps/website/src/app/pages/sync-remixed-playlist/sync-remixed-playlist-page.component.ts
+++ b/apps/website/src/app/pages/sync-remixed-playlist/sync-remixed-playlist-page.component.ts
@@ -30,6 +30,10 @@ export class SyncRemixedPlaylistPageComponent {
   arrowLeftIcon = faArrowLeft;
   isSyncing = false;
 
+  // Fields for storing fetched playlist details
+  originalPlaylist: SpotifyApi.SinglePlaylistResponse | undefined;
+  remixedPlaylist: SpotifyApi.SinglePlaylistResponse | undefined;
+
   constructor(
     private readonly router: Router,
     private apiService: ApiService,
@@ -49,8 +53,10 @@ export class SyncRemixedPlaylistPageComponent {
     }
   }
 
-  private load() {
+  private async load() {
     this.isComparisonLoading = true;
+    // Fetch playlist details as the first step
+    await this.fetchPlaylistDetails();
     this.apiService.comparePlaylists(this.originalPlaylistId, this.remixedPlaylistId)
       .then(changes => {
         // Automatically build the draft synced playlist with tracks that are:
@@ -65,6 +71,13 @@ export class SyncRemixedPlaylistPageComponent {
         // The changed tracks are then the ones that are in the list of changes, but not in the draft synced playlist
         this.changedTracks = _.differenceWith(changes, this.draftSyncedPlaylist, (a: Diff, b: Diff) => a[1].track.id === b[1].track.id);
       }).finally(() => this.isComparisonLoading = false);
+  }
+
+  private async fetchPlaylistDetails() {
+    // Fetch the original playlist details
+    this.originalPlaylist = await this.apiService.getPlaylist(this.originalPlaylistId);
+    // Fetch the remixed playlist details
+    this.remixedPlaylist = await this.apiService.getPlaylist(this.remixedPlaylistId);
   }
 
   /**


### PR DESCRIPTION
Related to #35

Implements the display of original and remixed playlist details on the synchronization screen.

- **Playlist Details Fetching**: Adds functionality to fetch and store details of both the original and remixed playlists from the Spotify API. This includes the playlists' names, descriptions, and cover images.
- **UI Enhancement**: Updates the synchronization screen's HTML to include sections for displaying the fetched details of the original and remixed playlists. Each section shows the playlist's cover image, name, and description, with the original playlist's details on the left and the remixed playlist's details on the right, adhering to the specified layout.
- **Styling**: Applies the `bg-base-300` class for the background of both playlist detail containers, ensuring they have rounded corners and a consistent appearance with the rest of the application's design.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Staijn1/SpotifyManager/issues/35?shareId=5fb2ae6f-7f97-4fd2-9d71-631d40716897).