### PR TITLE
Add synchronization link to original playlist update emails

### DIFF
--- a/apps/api/src/app/modules/mail/services/mail-service/mail.service.ts
+++ b/apps/api/src/app/modules/mail/services/mail-service/mail.service.ts
@@ -6,7 +6,7 @@ import { DiffIdentifier, EmailNotificationFrequency, Utils } from '@spotify-mana
 import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { PlaylistService } from '../../../playlist/services/playlist/playlist.service';
 import { SpotifyService } from '../../../spotify/spotify/spotify.service';
-
+import { environment } from '../../../../../environments/environment';
 
 @Injectable()
 export class MailService {
@@ -22,7 +22,6 @@ export class MailService {
 
   private async sendMail(options: ISendMailOptions) {
     const overrideEmail = this.configService.get('OVERRIDE_EMAIL');
-    // OverrideEmail is a comma seperated list of emails to override emails to, or it is NONE. If undefined or empty string no emails are sent
     if (!overrideEmail) {
       this.logger.warn('No override email set, no emails will be sent. To send emails to real users set OVERRIDE_EMAIL to NONE');
       return;
@@ -38,9 +37,6 @@ export class MailService {
     this.logger.log(`Sent email successfully`);
   }
 
-  /**
-   * For each user that has not been notified within their given preference, send an email if one of the original playlists have been updated of their remixed playlists.
-   */
   async sendOriginalPlaylistUpdatedEmails() {
     this.logger.log('Starting change-detection for original playlist of remixed playlists');
     const users = await this.userPreferenceService.getUnnotifiedUsers(EmailType.ORIGINAL_PLAYLIST_CHANGE_NOTIFICATION);
@@ -60,17 +56,16 @@ export class MailService {
         appInfo: {
           github: 'https://github.com/Staijn1/SpotifyManager',
           appUrl: 'https://spotify.steinjonker.nl'
-        }
+        },
+        synchronizePlaylistUrl: this.getSynchronizePlaylistUrl()
       };
 
-      // Remixed playlists where the original playlist update notification is not ignored
       const remixesNotIgnored = remixes.filter(remix => !user.excludedPlaylistIdsFromOriginalPlaylistUpdatedNotifications.includes(remix.id));
       for (const remix of remixesNotIgnored) {
         const differences = await this.playlistService.compareRemixedPlaylistWithOriginal(remix.id, user.userId);
         const songsAddedInOriginal = differences.filter(diff => diff[0] === DiffIdentifier.ADDED_IN_ORIGINAL);
         const songsRemovedInOriginal = differences.filter(diff => diff[0] === DiffIdentifier.REMOVED_IN_ORIGINAL);
 
-        // Stop if no songs have been added or removed
         if (songsAddedInOriginal.length == 0 && songsRemovedInOriginal.length == 0) {
           continue;
         }
@@ -80,7 +75,8 @@ export class MailService {
           amountOfSongsRemovedInOriginal: songsRemovedInOriginal.length,
           playlistTitle: remix.name,
           playlistUrl: remix.external_urls.spotify,
-          playlistCoverUrl: remix.images[0].url
+          playlistCoverUrl: remix.images[0].url,
+          synchronizePlaylistUrl: `${userEmailContext.synchronizePlaylistUrl}/${remix.id}`
         });
       }
 
@@ -105,7 +101,6 @@ export class MailService {
 
     this.logger.log(`Done processing change-detection for remixed playlists. ${amountOfUsersWithUpdatedOriginalPlaylists} user(s) will be notified, sending emails now`);
 
-
     for (const userPromises of promises.entries()) {
       try {
         const promises = userPromises[1];
@@ -116,6 +111,10 @@ export class MailService {
       }
     }
   }
+
+  private getSynchronizePlaylistUrl(): string {
+    return environment.production ? 'https://spotify.steinjonker.nl/sync-remixed-playlist' : 'http://localhost:4200/sync-remixed-playlist';
+  }
 }
 
 export type OriginalPlaylistUpdatedEmailContext = {
@@ -123,17 +122,20 @@ export type OriginalPlaylistUpdatedEmailContext = {
     amountOfSongsAddedInOrginal: number,
     amountOfSongsRemovedInOriginal: number,
     playlistTitle: string,
-    playlistUrl: string
-    playlistCoverUrl: string
+    playlistUrl: string,
+    playlistCoverUrl: string,
+    synchronizePlaylistUrl: string
   }[];
 
   user: {
     email: string,
     username: string
-  }
+  };
 
   appInfo: {
     github: string,
     appUrl: string
-  }
+  };
+
+  synchronizePlaylistUrl: string;
 }

--- a/apps/api/src/app/modules/mail/services/mail-service/mail.service.ts
+++ b/apps/api/src/app/modules/mail/services/mail-service/mail.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { UserPreferencesService } from '../../../user-preferences/services/user-preferences.service';
 import { EmailType } from '../../../../types/EmailType';
-import { DiffIdentifier, EmailNotificationFrequency, Utils } from '@spotify-manager/core';
+import { DiffIdentifier } from '@spotify-manager/core';
 import { ISendMailOptions, MailerService } from '@nestjs-modules/mailer';
 import { PlaylistService } from '../../../playlist/services/playlist/playlist.service';
 import { SpotifyService } from '../../../spotify/spotify/spotify.service';
@@ -22,6 +22,7 @@ export class MailService {
 
   private async sendMail(options: ISendMailOptions) {
     const overrideEmail = this.configService.get('OVERRIDE_EMAIL');
+    // OverrideEmail is a comma seperated list of emails to override emails to, or it is NONE. If undefined or empty string no emails are sent
     if (!overrideEmail) {
       this.logger.warn('No override email set, no emails will be sent. To send emails to real users set OVERRIDE_EMAIL to NONE');
       return;
@@ -37,6 +38,9 @@ export class MailService {
     this.logger.log(`Sent email successfully`);
   }
 
+  /**
+   * For each user that has not been notified within their given preference, send an email if one of the original playlists have been updated of their remixed playlists.
+   */
   async sendOriginalPlaylistUpdatedEmails() {
     this.logger.log('Starting change-detection for original playlist of remixed playlists');
     const users = await this.userPreferenceService.getUnnotifiedUsers(EmailType.ORIGINAL_PLAYLIST_CHANGE_NOTIFICATION);
@@ -57,15 +61,16 @@ export class MailService {
           github: 'https://github.com/Staijn1/SpotifyManager',
           appUrl: 'https://spotify.steinjonker.nl'
         },
-        synchronizePlaylistUrl: this.getSynchronizePlaylistUrl()
       };
 
+      // Remixed playlists where the original playlist update notification is not ignored
       const remixesNotIgnored = remixes.filter(remix => !user.excludedPlaylistIdsFromOriginalPlaylistUpdatedNotifications.includes(remix.id));
       for (const remix of remixesNotIgnored) {
         const differences = await this.playlistService.compareRemixedPlaylistWithOriginal(remix.id, user.userId);
         const songsAddedInOriginal = differences.filter(diff => diff[0] === DiffIdentifier.ADDED_IN_ORIGINAL);
         const songsRemovedInOriginal = differences.filter(diff => diff[0] === DiffIdentifier.REMOVED_IN_ORIGINAL);
 
+        // Stop if no songs have been added or removed
         if (songsAddedInOriginal.length == 0 && songsRemovedInOriginal.length == 0) {
           continue;
         }
@@ -76,7 +81,7 @@ export class MailService {
           playlistTitle: remix.name,
           playlistUrl: remix.external_urls.spotify,
           playlistCoverUrl: remix.images[0].url,
-          synchronizePlaylistUrl: `${userEmailContext.synchronizePlaylistUrl}/${remix.id}`
+          synchronizePlaylistUrl: `${this.getSynchronizePlaylistUrl()}/${remix.id}`
         });
       }
 
@@ -136,6 +141,4 @@ export type OriginalPlaylistUpdatedEmailContext = {
     github: string,
     appUrl: string
   };
-
-  synchronizePlaylistUrl: string;
 }

--- a/apps/api/src/assets/mail-templates/original-playlist-updated.hbs
+++ b/apps/api/src/assets/mail-templates/original-playlist-updated.hbs
@@ -76,6 +76,7 @@
                           <h3>{{playlistTitle}}</h3>
                           <p>Songs added: {{amountOfSongsAddedInOrginal}}</p>
                           <p>Songs removed: {{amountOfSongsRemovedInOriginal}}</p>
+                          <a href="{{synchronizePlaylistUrl}}" class="hover-important-text-decoration-underline" style="color: #4338ca; text-decoration: none">Synchronize Playlist</a>
                         </div>
                       </div>
                     </div>
@@ -96,7 +97,7 @@
                     Powered by Spotify Manager
                   </p>
                   <p style="cursor: default">
-                    <a href="{{appInfo.github}}" class="hover-important-text-decoration-underline" style="color: #4338ca; text-decoration: none">
+                    <a href="{{appInfo.github}}" class="hover-important-text-decoration-underline" style="color: #4338ca; text-decoration: none;">
                       <img src="images/github-icon.png" alt="GitHub" style="max-width: 100%; vertical-align: middle; line-height: 1;">
                     </a>
                     &bull;

--- a/apps/mail-templates/src/templates/original-playlist-updated.html
+++ b/apps/mail-templates/src/templates/original-playlist-updated.html
@@ -39,6 +39,7 @@ bodyClass: bg-slate-50
                         <h3>@{{playlistTitle}}</h3>
                         <p>Songs added: @{{amountOfSongsAddedInOrginal}}</p>
                         <p>Songs removed: @{{amountOfSongsRemovedInOriginal}}</p>
+                        <a href="@{{synchronizePlaylistUrl}}" class="text-indigo-700 [text-decoration:none] hover:![text-decoration:underline]">Synchronize Playlist</a>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
Related to #44

Adds a "Synchronize Playlist" link to the email notification for updated original playlists, enabling direct synchronization of remixed playlists.

- **Email Template Update**: Modifies `apps/mail-templates/src/templates/original-playlist-updated.html` to include a "Synchronize Playlist" link within each playlist's section. This link dynamically generates URLs for synchronizing the respective remixed playlist.
- **Mail Service Logic**: Enhances `apps/api/src/app/modules/mail/services/mail-service/mail.service.ts` to support the new "Synchronize Playlist" link. It introduces a method to determine the base URL based on the environment (development or production) and dynamically inserts the `remixPlaylistId` into the URL for the synchronization link. This ensures that the correct URL is included in the email context for each remixed playlist.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Staijn1/SpotifyManager/issues/44?shareId=afeaf6ca-9bd4-4656-8198-655fb935a484).