### PR TITLE
Add warning for ignored playlists in email notifications

### DIFF
--- a/.run/build-emails.run.xml
+++ b/.run/build-emails.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build-emails" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/apps/mail-templates/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="build" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/preview-emails.run.xml
+++ b/.run/preview-emails.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="preview-emails" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/apps/mail-templates/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="dev" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/apps/api/src/app/modules/mail/services/mail-service/mail.service.ts
+++ b/apps/api/src/app/modules/mail/services/mail-service/mail.service.ts
@@ -61,6 +61,7 @@ export class MailService {
           github: 'https://github.com/Staijn1/SpotifyManager',
           appUrl: 'https://spotify.steinjonker.nl'
         },
+        ignoredPlaylistsCount: user.excludedPlaylistIdsFromOriginalPlaylistUpdatedNotifications.length
       };
 
       // Remixed playlists where the original playlist update notification is not ignored
@@ -141,4 +142,6 @@ export type OriginalPlaylistUpdatedEmailContext = {
     github: string,
     appUrl: string
   };
+
+  ignoredPlaylistsCount: number;
 }

--- a/apps/api/src/assets/mail-templates/original-playlist-updated.hbs
+++ b/apps/api/src/assets/mail-templates/original-playlist-updated.hbs
@@ -64,7 +64,11 @@
                   <p style="margin: 0; line-height: 24px">
                     Some of your remixed playlists have original playlists that have updated since your remix or last synchronization. Navigate to Spotify Manager to get up-to-date quickly!
                   </p>
-                  <div role="separator" style="line-height: 24px">&zwj;</div> {{#each updatedRemixes as |remix|}}
+                  <div role="separator" style="line-height: 24px">&zwj;</div> undefined
+                  <p role="alert" style="margin: 0; border-radius: 4px; border-left-width: 4px; border-color: #eab308; background-color: #fef9c3; padding: 16px; line-height: 24px; color: #a16207">
+                    You have configured some of your remixed playlists to be excluded from this email-notification. Please sign in to Spotify Manager and check if they need synchronizing yourself!
+                  </p>
+                  <div role="separator" style="line-height: 24px">&zwj;</div> undefined {{#each updatedRemixes as |remix|}}
                     <div style="display: flex; height: 100%; overflow: hidden; border-radius: 8px">
                       <div>
                         <a href="{{playlistUrl}}" target="_blank">

--- a/apps/mail-templates/package-lock.json
+++ b/apps/mail-templates/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "maizzle",
+  "name": "mail-templates",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/apps/mail-templates/src/templates/original-playlist-updated.html
+++ b/apps/mail-templates/src/templates/original-playlist-updated.html
@@ -26,6 +26,13 @@ bodyClass: bg-slate-50
 
                 <x-spacer height="24px" />
 
+                {{#if ignoredPlaylistsCount}}
+                  <p class="m-0 leading-6 bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4" role="alert">
+                    You have configured some of your remixed playlists to be excluded from this email-notification. Please sign in to Spotify Manager and check if they need synchronizing yourself!
+                  </p>
+                  <x-spacer height="24px" />
+                {{/if}}
+
                 @{{#each updatedRemixes as |remix|}}
                   <div class="spotify-track-container bg-base-300 rounded-lg overflow-hidden flex h-full">
                     <div>

--- a/apps/mail-templates/src/templates/original-playlist-updated.html
+++ b/apps/mail-templates/src/templates/original-playlist-updated.html
@@ -27,7 +27,7 @@ bodyClass: bg-slate-50
                 <x-spacer height="24px" />
 
                 {{#if ignoredPlaylistsCount}}
-                  <p class="m-0 leading-6 bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4" role="alert">
+                  <p class="m-0 leading-6 bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 rounded" role="alert">
                     You have configured some of your remixed playlists to be excluded from this email-notification. Please sign in to Spotify Manager and check if they need synchronizing yourself!
                   </p>
                   <x-spacer height="24px" />


### PR DESCRIPTION
Related to #47

Adds a warning about ignored playlists in the email notifications for original playlist updates.

- **Email Context Enhancement**: Modifies `sendOriginalPlaylistUpdatedEmails` in `apps/api/src/app/modules/mail/services/mail-service/mail.service.ts` to include the count of ignored playlists due to user settings in the email context. This is achieved by adding a new property `ignoredPlaylistsCount` to the `OriginalPlaylistUpdatedEmailContext` type and calculating the number of ignored playlists for each user.
- **Email Template Update**: Updates the email template `apps/mail-templates/src/templates/original-playlist-updated.html` to display a warning message if there are any ignored playlists. The warning informs users that some of their remixed playlists are excluded from the notification due to their settings, urging them to check these playlists manually.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Staijn1/SpotifyManager/issues/47?shareId=30b37b06-b477-49a6-9e8e-1da58d366c8b).